### PR TITLE
Emulator is always monitoring disabled? and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Release Notes
 
+### 1.3.0
+ * feat: add battery monitoring and detailed power state getter (https://github.com/react-native-community/react-native-device-info/pull/436)
+
 ### 1.2.0
  * feat: Support 'dom' Platform.OS for react-native-dom (https://github.com/react-native-community/react-native-device-info/pull/406)
  * feat: Add support for jest snapshot testing (https://github.com/react-native-community/react-native-device-info/pull/375)

--- a/README.md
+++ b/README.md
@@ -656,6 +656,7 @@ const phoneNumber = DeviceInfo.getPhoneNumber();
 ### getPowerState()
 
 Gets the power state of the device including the battery level, whether it is plugged in, and if the system is currently operating in low power mode.
+Displays a warning on iOS if battery monitoring not enabled, or if attempted on an emulator (where montioring is not possible)
 
 **Examples**
 

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -433,7 +433,7 @@ RCT_EXPORT_METHOD(isPinOrFingerprintSet:(RCTResponseSenderBlock)callback)
 
 - (NSDictionary *)powerState
 {
-#if RCT_DEV
+#if RCT_DEV && (!TARGET_IPHONE_SIMULATOR)
     if ([UIDevice currentDevice].isBatteryMonitoringEnabled != true) {
         RCTLogWarn(@"Battery monitoring is not enabled. "
                    "You need to enable monitoring with `[UIDevice currentDevice].batteryMonitoringEnabled = TRUE`");
@@ -441,7 +441,7 @@ RCT_EXPORT_METHOD(isPinOrFingerprintSet:(RCTResponseSenderBlock)callback)
 #endif
 #if RCT_DEV && (TARGET_OS_TV || TARGET_IPHONE_SIMULATOR)
     if ([UIDevice currentDevice].batteryState == UIDeviceBatteryStateUnknown) {
-        RCTLogWarn(@"Battery state is `unknown` which is normal for simulators and tvOS.");
+        RCTLogWarn(@"Battery state `unknown` and monitoring disabled, this is normal for simulators and tvOS.");
     }
 #endif
 


### PR DESCRIPTION
This thing is subtle! In my testing (on an old iPad, and emulators) I noticed that the emulators were *always* showing the "you need to add the monitoring to your appdelegate" warning even though it was definitely there, and my ipad was fine.

So I infer that simulators are always "isBatteryMonitoringEnabled == false" no matter what you do, and I altered the macro conditional accordingly.

I would have just made the change and merged it (this thing is ready!) but I thought you might want a pass at it to make sure my change is sane...